### PR TITLE
Refactor: Update Hierarchical Deterministic Key Derivation

### DIFF
--- a/packages/features/src/common/store/vault.test.ts
+++ b/packages/features/src/common/store/vault.test.ts
@@ -94,7 +94,7 @@ describe('VaultStore', () => {
         mnemonic
       })
       expect(wallet.publicKey).toEqual(
-        'B62qnHVdf5V7JTiRJDZMXrLNxdcH3xGamp5fUs6uMo5TuwMGHdt1dW2'
+        'B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb'
       )
     })
     expect(result.current.credentials.length).toEqual(1)

--- a/packages/features/src/common/store/vault.ts
+++ b/packages/features/src/common/store/vault.ts
@@ -67,7 +67,7 @@ export const useVaultStore = create<VaultStore>()(
       async createWallet({ walletName }) {
         const { addCredential, setCurrentWalletPublicKey } = get()
         const mnemonic = generateMnemonic(wordlist)
-        const keypair = await deriveKeyPair({ mnemonic })
+        const keypair = await deriveKeyPair({ mnemonic, accountNumber: 0 })
         if (!keypair) return null
         addCredential({
           walletName,
@@ -84,7 +84,7 @@ export const useVaultStore = create<VaultStore>()(
       },
       async restoreWallet({ walletName, mnemonic }) {
         const { addCredential, setCurrentWalletPublicKey } = get()
-        const keypair = await deriveKeyPair({ mnemonic })
+        const keypair = await deriveKeyPair({ mnemonic, accountNumber: 0 })
         if (!keypair) return null
         addCredential({
           walletName,

--- a/packages/mina/src/hd.test.ts
+++ b/packages/mina/src/hd.test.ts
@@ -38,7 +38,8 @@ it('derives a keypair', async () => {
 })
 
 it('derives different keypairs for different account numbers', async () => {
-  const mnemonic = 'habit hope tip crystal because grunt nation idea electric witness alert like'
+  const mnemonic =
+    'habit hope tip crystal because grunt nation idea electric witness alert like'
   const keypair1 = await deriveKeyPair({ mnemonic, accountNumber: 0 })
   const keypair2 = await deriveKeyPair({ mnemonic, accountNumber: 1 })
   expect(keypair1?.publicKey).not.toEqual(keypair2?.publicKey)

--- a/packages/mina/src/hd.test.ts
+++ b/packages/mina/src/hd.test.ts
@@ -29,9 +29,17 @@ it('validates mnemonics', () => {
 it('derives a keypair', async () => {
   const keypair = await deriveKeyPair({
     mnemonic:
-      'habit hope tip crystal because grunt nation idea electric witness alert like'
+      'habit hope tip crystal because grunt nation idea electric witness alert like',
+    accountNumber: 0
   })
   expect(keypair?.publicKey).toEqual(
-    'B62qnHVdf5V7JTiRJDZMXrLNxdcH3xGamp5fUs6uMo5TuwMGHdt1dW2'
+    'B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb'
   )
+})
+
+it('derives different keypairs for different account numbers', async () => {
+  const mnemonic = 'habit hope tip crystal because grunt nation idea electric witness alert like'
+  const keypair1 = await deriveKeyPair({ mnemonic, accountNumber: 0 })
+  const keypair2 = await deriveKeyPair({ mnemonic, accountNumber: 1 })
+  expect(keypair1?.publicKey).not.toEqual(keypair2?.publicKey)
 })

--- a/packages/mina/src/hd.ts
+++ b/packages/mina/src/hd.ts
@@ -5,8 +5,7 @@ import { Buffer } from 'buffer'
 import Client from 'mina-signer'
 export { generateMnemonic, validateMnemonic } from '@scure/bip39'
 export { wordlist } from '@scure/bip39/wordlists/english'
-import { MinaKeyConst, MinaHDPath } from './types'
-
+import { MinaHDPath, MinaKeyConst } from './types'
 
 export const minaClient = new Client({ network: 'testnet' })
 
@@ -26,12 +25,12 @@ export const deriveWalletByMnemonic = async (
 ) => {
   const seed = mnemonicToSeedSync(mnemonic)
   const masterNode = HDKey.fromMasterSeed(seed)
-  
+
   // Create a MinaHDPath object
   const hdPathObject: MinaHDPath = {
     accountIndex: accountNumber,
-    change: 0,  // According to BIP44, this is typically 0 for external (receiving) and 1 for internal (change)
-    index: 0    // This is the address_index, you can change it if you want to generate more addresses from the same account
+    change: 0, // According to BIP44, this is typically 0 for external (receiving) and 1 for internal (change)
+    index: 0 // This is the address_index, you can change it if you want to generate more addresses from the same account
   }
   // Derive the BIP32 path from the hdPathObject
   const hdPath = getHierarchicalDeterministicPath(hdPathObject)
@@ -50,7 +49,13 @@ export const deriveWalletByMnemonic = async (
   }
 }
 
-export const deriveKeyPair = async ({ mnemonic, accountNumber = 0 }: { mnemonic: string, accountNumber?: number }) => {
+export const deriveKeyPair = async ({
+  mnemonic,
+  accountNumber = 0
+}: {
+  mnemonic: string
+  accountNumber?: number
+}) => {
   const keys = await deriveWalletByMnemonic(mnemonic, accountNumber)
   if (keys) {
     const { privateKey, publicKey } = keys

--- a/packages/mina/src/hd.ts
+++ b/packages/mina/src/hd.ts
@@ -5,21 +5,19 @@ import { Buffer } from 'buffer'
 import Client from 'mina-signer'
 export { generateMnemonic, validateMnemonic } from '@scure/bip39'
 export { wordlist } from '@scure/bip39/wordlists/english'
+import { MinaKeyConst, MinaHDPath } from './types'
+
 
 export const minaClient = new Client({ network: 'testnet' })
-
-const MINA_COIN_INDEX = 12586
 
 const reverseBytes = (bytes: Buffer) => {
   const uint8 = new Uint8Array(bytes)
   return new Buffer(uint8.reverse())
 }
 
-export const getHierarchicalDeterministicPath = ({ accountNumber = 0 }) => {
-  const purse = 44
-  const index = 0
-  const charge = 0
-  return `m/${purse}/${MINA_COIN_INDEX}/${accountNumber}/${charge}/${index}`
+export const getHierarchicalDeterministicPath = (path: MinaHDPath) => {
+  const { accountIndex = 0, change = 0, index = 0 } = path
+  return `m/${MinaKeyConst.PURPOSE}'/${MinaKeyConst.COIN_TYPE}'/${accountIndex}'/${change}/${index}`
 }
 
 export const deriveWalletByMnemonic = async (
@@ -28,7 +26,16 @@ export const deriveWalletByMnemonic = async (
 ) => {
   const seed = mnemonicToSeedSync(mnemonic)
   const masterNode = HDKey.fromMasterSeed(seed)
-  const hdPath = getHierarchicalDeterministicPath({ accountNumber })
+  
+  // Create a MinaHDPath object
+  const hdPathObject: MinaHDPath = {
+    accountIndex: accountNumber,
+    change: 0,  // According to BIP44, this is typically 0 for external (receiving) and 1 for internal (change)
+    index: 0    // This is the address_index, you can change it if you want to generate more addresses from the same account
+  }
+  // Derive the BIP32 path from the hdPathObject
+  const hdPath = getHierarchicalDeterministicPath(hdPathObject)
+
   const child0 = masterNode.derive(hdPath)
   if (!child0?.privateKey) return null
   child0.privateKey[0] &= 0x3f
@@ -43,8 +50,8 @@ export const deriveWalletByMnemonic = async (
   }
 }
 
-export const deriveKeyPair = async ({ mnemonic }: { mnemonic: string }) => {
-  const keys = await deriveWalletByMnemonic(mnemonic)
+export const deriveKeyPair = async ({ mnemonic, accountNumber = 0 }: { mnemonic: string, accountNumber?: number }) => {
+  const keys = await deriveWalletByMnemonic(mnemonic, accountNumber)
   if (keys) {
     const { privateKey, publicKey } = keys
     return {

--- a/packages/mina/src/types.ts
+++ b/packages/mina/src/types.ts
@@ -3,3 +3,23 @@ export enum MinaNetwork {
   DEVNET = 'DEVNET',
   BERKELEY = 'BERKELEY'
 }
+
+export const enum MinaKeyConst {
+  PURPOSE = 44,
+  COIN_TYPE = 12586
+}
+
+// indexes for BIP32 path levels
+export const enum MinaPathLevelIndexes {
+  PURPOSE = 0,
+  COIN_TYPE = 1,
+  ACCOUNT = 2,
+  CHANGE = 3,
+  INDEX = 4
+}
+
+export interface MinaHDPath {
+  accountIndex: number;
+  change: number;
+  index: number;
+}

--- a/packages/mina/src/types.ts
+++ b/packages/mina/src/types.ts
@@ -19,7 +19,7 @@ export const enum MinaPathLevelIndexes {
 }
 
 export interface MinaHDPath {
-  accountIndex: number;
-  change: number;
-  index: number;
+  accountIndex: number
+  change: number
+  index: number
 }


### PR DESCRIPTION
## Refactor: Update Hierarchical Deterministic Key Derivation
This pull request introduces improvements to the key derivation process in the context of Hierarchical Deterministic (HD) wallets. With the new modifications, the key derivation process could support multiple accounts, which is a crucial feature for users wishing to manage more than one account. The update also uses the defined hardened derivation paths.

The changes introduced in this PR are as follows:
- Updated the `deriveKeyPair` function to accept an optional `accountNumber` parameter. If no account number is provided, the function defaults to account 0 (see `vault.ts` and `hd.ts`). This allows the key derivation process to generate keys for different accounts.

- Added a new test to ensure that the `deriveKeyPair` function generates different keys for different account numbers (see hd.test.ts).

- Updated the `getHierarchicalDeterministicPath` function to accept a `MinaHDPath` object which holds information about the account index, change, and index for generating the BIP44 path (see `hd.ts`).

- Introduced the `MinaHDPath`, `MinaKeyConst`, and `MinaPathLevelIndexes` interfaces and constants in types.ts to facilitate HD path generation.

- Refactored test cases to align with these changes (see `hd.test.ts` and `vault.test.ts`).

Have a look at the proposed changes; I appreciate any feedback or questions you may have 😄 